### PR TITLE
change ethereum library

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"license": "MPL-2.0",
 	"dependencies": {
 		"ramda": "^0.27.1",
-		"web3": "^1.2.11"
+                "ethereum-waffle": "3.2.0"
 	},
 	"devDependencies": {
 		"@ava/typescript": "1.1.1",


### PR DESCRIPTION
# description

change ethereum library
(web3->ethers)

# why

ethers(waffle) is simpler and faster than web3(Truffle)